### PR TITLE
add namespace + CPM compliant

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .idea
 build
+cmake-build-debug
+cmake-build-release

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,62 @@
-cmake_minimum_required(VERSION 3.6)
-project(ProgressBar)
+cmake_minimum_required(VERSION 3.14 FATAL_ERROR)
 
-set(CMAKE_CXX_STANDARD 11)
+# ---- Project ----
 
-set(SOURCE_FILES main.cpp)
-add_executable(ProgressBar ${SOURCE_FILES})
+# Note: update this to your new project's name and version
+project(progresscpp
+        VERSION 1.0
+        LANGUAGES CXX
+        )
+
+# ---- Include guards ----
+
+if(PROJECT_SOURCE_DIR STREQUAL PROJECT_BINARY_DIR)
+    message(FATAL_ERROR "In-source builds not allowed. Please make a new directory (called a build directory) and run CMake from there.")
+endif()
+
+# ---- Add dependencies via CPM ----
+# see https://github.com/TheLartians/CPM.cmake for more info
+
+include(cmake/CPM.cmake)
+
+# PackageProject.cmake will be used to make our target installable
+CPMAddPackage(
+        NAME PackageProject.cmake
+        GITHUB_REPOSITORY TheLartians/PackageProject.cmake
+        VERSION 1.0
+)
+
+# ---- Add source files ----
+
+# Note: globbing sources is considered bad practice as CMake's generators may not detect new files automatically.
+# Keep that in mind when changing files, or explicitly mention them here.
+FILE(GLOB_RECURSE headers CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/include/**/*.h")
+
+# ---- Create library ----
+
+# Note: for header-only libraries change all PUBLIC flags to INTERFACE and create an interface target:
+add_library(progresscpp INTERFACE ${headers})
+set_target_properties(progresscpp PROPERTIES INTERFACE_COMPILE_FEATURES cxx_std_11)
+
+# beeing a cross-platform target, we enforce enforce standards conformance on MSVC
+target_compile_options(progresscpp INTERFACE "$<$<BOOL:${MSVC}>:/permissive->")
+
+# Link dependencies (if required)
+# target_link_libraries(Greeter PUBLIC cxxopts)
+
+target_include_directories(progresscpp
+        INTERFACE
+        $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
+        $<INSTALL_INTERFACE:include/${PROJECT_NAME}-${PROJECT_VERSION}>
+        )
+
+# ---- Create an installable target ----
+# this allows users to install and find the library via `find_package()`.
+
+packageProject(
+        NAME ${PROJECT_NAME}
+        VERSION ${PROJECT_VERSION}
+        BINARY_DIR ${PROJECT_BINARY_DIR}
+        INCLUDE_DIR ${PROJECT_SOURCE_DIR}/include
+        INCLUDE_DESTINATION include/${PROJECT_NAME}-${PROJECT_VERSION}
+)

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ The above code results in the following output
 ```
 
 ### Example
-Refer to [main.cpp](main.cpp) file for an example usage. To run it,
+Refer to [main.cpp](example/src/example.cpp) file for an example usage. To run it,
 
 ```
 $ mkdir build && cd build
@@ -56,5 +56,5 @@ $ g++ -O3 -I. main.cpp -Wall -std=c++11 -o ProgressBar
 $ ./ProgressBar
 ```
 
-### License
-MIT
+### CMake configuration
+Cmake and project layout is inspired by [github.com/TheLartians/ModernCppStarter](https://github.com/TheLartians/ModernCppStarter).

--- a/cmake/CPM.cmake
+++ b/cmake/CPM.cmake
@@ -1,0 +1,329 @@
+# TheLartians/CPM - A simple Git dependency manager
+# =================================================
+# See https://github.com/TheLartians/CPM for usage and update instructions.
+#
+# MIT License
+# -----------
+#[[
+  Copyright (c) 2019 Lars Melchior
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in all
+  copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+]]
+
+cmake_minimum_required(VERSION 3.14 FATAL_ERROR)
+
+set(CURRENT_CPM_VERSION 0.18)
+
+if(CPM_DIRECTORY)
+    if(NOT ${CPM_DIRECTORY} MATCHES ${CMAKE_CURRENT_LIST_DIR})
+        if (${CPM_VERSION} VERSION_LESS ${CURRENT_CPM_VERSION})
+            message(AUTHOR_WARNING "${CPM_INDENT} \
+A dependency is using a more recent CPM version (${CURRENT_CPM_VERSION}) than the current project (${CPM_VERSION}). \
+It is recommended to upgrade CPM to the most recent version. \
+See https://github.com/TheLartians/CPM.cmake for more information."
+                    )
+        endif()
+        return()
+    endif()
+endif()
+
+option(CPM_USE_LOCAL_PACKAGES "Always try to use `find_package` to get dependencies" $ENV{CPM_USE_LOCAL_PACKAGES})
+option(CPM_LOCAL_PACKAGES_ONLY "Only use `find_package` to get dependencies" $ENV{CPM_LOCAL_PACKAGES_ONLY})
+option(CPM_DOWNLOAD_ALL "Always download dependencies from source" $ENV{CPM_DOWNLOAD_ALL})
+
+set(CPM_VERSION ${CURRENT_CPM_VERSION} CACHE INTERNAL "")
+set(CPM_DIRECTORY ${CMAKE_CURRENT_LIST_DIR} CACHE INTERNAL "")
+set(CPM_PACKAGES "" CACHE INTERNAL "")
+set(CPM_DRY_RUN OFF CACHE INTERNAL "Don't download or configure dependencies (for testing)")
+
+if(DEFINED ENV{CPM_SOURCE_CACHE})
+    set(CPM_SOURCE_CACHE_DEFAULT $ENV{CPM_SOURCE_CACHE})
+else()
+    set(CPM_SOURCE_CACHE_DEFAULT OFF)
+endif()
+
+set(CPM_SOURCE_CACHE ${CPM_SOURCE_CACHE_DEFAULT} CACHE PATH "Directory to downlaod CPM dependencies")
+
+include(FetchContent)
+include(CMakeParseArguments)
+
+# Initialize logging prefix
+if(NOT CPM_INDENT)
+    set(CPM_INDENT "CPM:")
+endif()
+
+function(cpm_find_package NAME VERSION)
+    string(REPLACE " " ";" EXTRA_ARGS "${ARGN}")
+    find_package(${NAME} ${VERSION} ${EXTRA_ARGS} QUIET)
+    if(${CPM_ARGS_NAME}_FOUND)
+        message(STATUS "${CPM_INDENT} using local package ${CPM_ARGS_NAME}@${${CPM_ARGS_NAME}_VERSION}")
+        CPMRegisterPackage(${CPM_ARGS_NAME} "${${CPM_ARGS_NAME}_VERSION}")
+        set(CPM_PACKAGE_FOUND YES PARENT_SCOPE)
+    else()
+        set(CPM_PACKAGE_FOUND NO PARENT_SCOPE)
+    endif()
+endfunction()
+
+# Find a package locally or fallback to CPMAddPackage
+function(CPMFindPackage)
+    set(oneValueArgs
+            NAME
+            VERSION
+            FIND_PACKAGE_ARGUMENTS
+            )
+
+    cmake_parse_arguments(CPM_ARGS "" "${oneValueArgs}" "" ${ARGN})
+
+    if (CPM_DOWNLOAD_ALL)
+        CPMAddPackage(${ARGN})
+        cpm_export_variables()
+        return()
+    endif()
+
+    cpm_find_package(${CPM_ARGS_NAME} "${CPM_ARGS_VERSION}" ${CPM_ARGS_FIND_PACKAGE_ARGUMENTS})
+
+    if(NOT CPM_PACKAGE_FOUND)
+        CPMAddPackage(${ARGN})
+        cpm_export_variables()
+    endif()
+
+endfunction()
+
+# Download and add a package from source
+function(CPMAddPackage)
+
+    set(oneValueArgs
+            NAME
+            VERSION
+            GIT_TAG
+            DOWNLOAD_ONLY
+            GITHUB_REPOSITORY
+            GITLAB_REPOSITORY
+            SOURCE_DIR
+            DOWNLOAD_COMMAND
+            FIND_PACKAGE_ARGUMENTS
+            )
+
+    set(multiValueArgs
+            OPTIONS
+            )
+
+    cmake_parse_arguments(CPM_ARGS "" "${oneValueArgs}" "${multiValueArgs}" "${ARGN}")
+
+    if(CPM_USE_LOCAL_PACKAGES OR CPM_LOCAL_PACKAGES_ONLY)
+        cpm_find_package(${CPM_ARGS_NAME} "${CPM_ARGS_VERSION}" ${CPM_ARGS_FIND_PACKAGE_ARGUMENTS})
+
+        if(CPM_PACKAGE_FOUND)
+            return()
+        endif()
+
+        if(CPM_LOCAL_PACKAGES_ONLY)
+            message(SEND_ERROR "CPM: ${CPM_ARGS_NAME} not found via find_package(${CPM_ARGS_NAME} ${CPM_ARGS_VERSION})")
+        endif()
+    endif()
+
+    if (NOT DEFINED CPM_ARGS_VERSION)
+        if (DEFINED CPM_ARGS_GIT_TAG)
+            cpm_get_version_from_git_tag("${CPM_ARGS_GIT_TAG}" CPM_ARGS_VERSION)
+        endif()
+        if (NOT DEFINED CPM_ARGS_VERSION)
+            set(CPM_ARGS_VERSION 0)
+        endif()
+    endif()
+
+    if (NOT DEFINED CPM_ARGS_GIT_TAG)
+        set(CPM_ARGS_GIT_TAG v${CPM_ARGS_VERSION})
+    endif()
+
+    list(APPEND CPM_ARGS_UNPARSED_ARGUMENTS GIT_TAG ${CPM_ARGS_GIT_TAG})
+
+    if(CPM_ARGS_DOWNLOAD_ONLY)
+        set(DOWNLOAD_ONLY ${CPM_ARGS_DOWNLOAD_ONLY})
+    else()
+        set(DOWNLOAD_ONLY NO)
+    endif()
+
+    if (CPM_ARGS_GITHUB_REPOSITORY)
+        list(APPEND CPM_ARGS_UNPARSED_ARGUMENTS GIT_REPOSITORY "https://github.com/${CPM_ARGS_GITHUB_REPOSITORY}.git")
+    endif()
+
+    if (CPM_ARGS_GITLAB_REPOSITORY)
+        list(APPEND CPM_ARGS_UNPARSED_ARGUMENTS GIT_REPOSITORY "https://gitlab.com/${CPM_ARGS_GITLAB_REPOSITORY}.git")
+    endif()
+
+    if (${CPM_ARGS_NAME} IN_LIST CPM_PACKAGES)
+        CPMGetPackageVersion(${CPM_ARGS_NAME} CPM_PACKAGE_VERSION)
+        if(${CPM_PACKAGE_VERSION} VERSION_LESS ${CPM_ARGS_VERSION})
+            message(WARNING "${CPM_INDENT} requires a newer version of ${CPM_ARGS_NAME} (${CPM_ARGS_VERSION}) than currently included (${CPM_PACKAGE_VERSION}).")
+        endif()
+        if (CPM_ARGS_OPTIONS)
+            foreach(OPTION ${CPM_ARGS_OPTIONS})
+                cpm_parse_option(${OPTION})
+                if(NOT "${${OPTION_KEY}}" STREQUAL ${OPTION_VALUE})
+                    message(WARNING "${CPM_INDENT} ignoring package option for ${CPM_ARGS_NAME}: ${OPTION_KEY} = ${OPTION_VALUE} (${${OPTION_KEY}})")
+                endif()
+            endforeach()
+        endif()
+        cpm_fetch_package(${CPM_ARGS_NAME} ${DOWNLOAD_ONLY})
+        cpm_get_fetch_properties(${CPM_ARGS_NAME})
+        SET(${CPM_ARGS_NAME}_SOURCE_DIR "${${CPM_ARGS_NAME}_SOURCE_DIR}")
+        SET(${CPM_ARGS_NAME}_BINARY_DIR "${${CPM_ARGS_NAME}_BINARY_DIR}")
+        SET(${CPM_ARGS_NAME}_ADDED NO)
+        cpm_export_variables()
+        return()
+    endif()
+
+    CPMRegisterPackage(${CPM_ARGS_NAME} ${CPM_ARGS_VERSION})
+
+    if (CPM_ARGS_OPTIONS)
+        foreach(OPTION ${CPM_ARGS_OPTIONS})
+            cpm_parse_option(${OPTION})
+            set(${OPTION_KEY} ${OPTION_VALUE} CACHE INTERNAL "")
+        endforeach()
+    endif()
+
+    set(FETCH_CONTENT_DECLARE_EXTRA_OPTS "")
+
+    if (DEFINED CPM_ARGS_GIT_TAG)
+        set(PACKAGE_INFO "${CPM_ARGS_GIT_TAG}")
+    else()
+        set(PACKAGE_INFO "${CPM_ARGS_VERSION}")
+    endif()
+
+    if (DEFINED CPM_ARGS_DOWNLOAD_COMMAND)
+        set(FETCH_CONTENT_DECLARE_EXTRA_OPTS DOWNLOAD_COMMAND ${CPM_ARGS_DOWNLOAD_COMMAND})
+    elseif(DEFINED CPM_ARGS_SOURCE_DIR)
+        set(FETCH_CONTENT_DECLARE_EXTRA_OPTS SOURCE_DIR ${CPM_ARGS_SOURCE_DIR})
+    elseif (CPM_SOURCE_CACHE)
+        string(TOLOWER ${CPM_ARGS_NAME} lower_case_name)
+        set(origin_parameters ${CPM_ARGS_UNPARSED_ARGUMENTS})
+        list(SORT origin_parameters)
+        string(SHA1 origin_hash "${origin_parameters}")
+        set(download_directory ${CPM_SOURCE_CACHE}/${lower_case_name}/${origin_hash})
+        list(APPEND FETCH_CONTENT_DECLARE_EXTRA_OPTS SOURCE_DIR ${download_directory})
+        if (EXISTS ${download_directory})
+            list(APPEND FETCH_CONTENT_DECLARE_EXTRA_OPTS DOWNLOAD_COMMAND ":")
+            set(PACKAGE_INFO "${download_directory}")
+        else()
+            # remove timestamps so CMake will re-download the dependency
+            file(REMOVE_RECURSE ${CMAKE_BINARY_DIR}/_deps/${lower_case_name}-subbuild)
+            set(PACKAGE_INFO "${PACKAGE_INFO} -> ${download_directory}")
+        endif()
+    endif()
+
+    cpm_declare_fetch(${CPM_ARGS_NAME} ${CPM_ARGS_VERSION} ${PACKAGE_INFO} "${CPM_ARGS_UNPARSED_ARGUMENTS}" ${FETCH_CONTENT_DECLARE_EXTRA_OPTS})
+    cpm_fetch_package(${CPM_ARGS_NAME} ${DOWNLOAD_ONLY})
+    cpm_get_fetch_properties(${CPM_ARGS_NAME})
+    SET(${CPM_ARGS_NAME}_ADDED YES)
+    cpm_export_variables()
+endfunction()
+
+# export variables available to the caller to the parent scope
+# expects ${CPM_ARGS_NAME} to be set
+macro(cpm_export_variables)
+    SET(${CPM_ARGS_NAME}_SOURCE_DIR "${${CPM_ARGS_NAME}_SOURCE_DIR}" PARENT_SCOPE)
+    SET(${CPM_ARGS_NAME}_BINARY_DIR "${${CPM_ARGS_NAME}_BINARY_DIR}" PARENT_SCOPE)
+    SET(${CPM_ARGS_NAME}_ADDED "${${CPM_ARGS_NAME}_ADDED}" PARENT_SCOPE)
+endmacro()
+
+# declares that a package has been added to CPM
+function(CPMRegisterPackage PACKAGE VERSION)
+    list(APPEND CPM_PACKAGES ${PACKAGE})
+    set(CPM_PACKAGES ${CPM_PACKAGES} CACHE INTERNAL "")
+    set("CPM_PACKAGE_${PACKAGE}_VERSION" ${VERSION} CACHE INTERNAL "")
+endfunction()
+
+# retrieve the current version of the package to ${OUTPUT}
+function(CPMGetPackageVersion PACKAGE OUTPUT)
+    set(${OUTPUT} "${CPM_PACKAGE_${PACKAGE}_VERSION}" PARENT_SCOPE)
+endfunction()
+
+# declares a package in FetchContent_Declare
+function (cpm_declare_fetch PACKAGE VERSION INFO)
+    message(STATUS "${CPM_INDENT} adding package ${PACKAGE}@${VERSION} (${INFO})")
+
+    if (${CPM_DRY_RUN})
+        message(STATUS "${CPM_INDENT} package not declared (dry run)")
+        return()
+    endif()
+
+    FetchContent_Declare(
+            ${PACKAGE}
+            ${ARGN}
+    )
+endfunction()
+
+# returns properties for a package previously defined by cpm_declare_fetch
+function (cpm_get_fetch_properties PACKAGE)
+    if (${CPM_DRY_RUN})
+        return()
+    endif()
+    FetchContent_GetProperties(${PACKAGE})
+    string(TOLOWER ${PACKAGE} lpackage)
+    SET(${PACKAGE}_SOURCE_DIR "${${lpackage}_SOURCE_DIR}" PARENT_SCOPE)
+    SET(${PACKAGE}_BINARY_DIR "${${lpackage}_BINARY_DIR}" PARENT_SCOPE)
+endfunction()
+
+# downloads a previously declared package via FetchContent
+function (cpm_fetch_package PACKAGE DOWNLOAD_ONLY)
+
+    if (${CPM_DRY_RUN})
+        message(STATUS "${CPM_INDENT} package ${PACKAGE} not fetched (dry run)")
+        return()
+    endif()
+
+    set(CPM_OLD_INDENT "${CPM_INDENT}")
+    set(CPM_INDENT "${CPM_INDENT} ${PACKAGE}:")
+    if(${DOWNLOAD_ONLY})
+        if(NOT "${PACKAGE}_POPULATED")
+            FetchContent_Populate(${PACKAGE})
+        endif()
+    else()
+        FetchContent_MakeAvailable(${PACKAGE})
+    endif()
+    set(CPM_INDENT "${CPM_OLD_INDENT}")
+endfunction()
+
+# splits a package option
+function(cpm_parse_option OPTION)
+    string(REGEX MATCH "^[^ ]+" OPTION_KEY ${OPTION})
+    string(LENGTH ${OPTION} OPTION_LENGTH)
+    string(LENGTH ${OPTION_KEY} OPTION_KEY_LENGTH)
+    if (OPTION_KEY_LENGTH STREQUAL OPTION_LENGTH)
+        # no value for key provided, assume user wants to set option to "ON"
+        set(OPTION_VALUE "ON")
+    else()
+        math(EXPR OPTION_KEY_LENGTH "${OPTION_KEY_LENGTH}+1")
+        string(SUBSTRING ${OPTION} "${OPTION_KEY_LENGTH}" "-1" OPTION_VALUE)
+    endif()
+    set(OPTION_KEY "${OPTION_KEY}" PARENT_SCOPE)
+    set(OPTION_VALUE "${OPTION_VALUE}" PARENT_SCOPE)
+endfunction()
+
+# guesses the package version from a git tag
+function(cpm_get_version_from_git_tag GIT_TAG RESULT)
+    string(LENGTH ${GIT_TAG} length)
+    if (length EQUAL 40)
+        # GIT_TAG is probably a git hash
+        SET(${RESULT} 0 PARENT_SCOPE)
+    else()
+        string(REGEX MATCH "v?([0123456789.]*).*" _ ${GIT_TAG})
+        SET(${RESULT} ${CMAKE_MATCH_1} PARENT_SCOPE)
+    endif()
+endfunction()

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -1,0 +1,27 @@
+cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
+
+project(progresscppExample
+        LANGUAGES CXX
+        )
+
+# ---- Dependencies ----
+
+include(../cmake/CPM.cmake)
+
+CPMAddPackage(
+        NAME progresscpp
+        SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}/..
+)
+
+# ---- Create standalone executable ----
+
+file(GLOB sources CONFIGURE_DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp)
+
+add_executable(progresscppExample ${sources})
+
+set_target_properties(progresscppExample PROPERTIES
+        CXX_STANDARD 11
+        OUTPUT_NAME "Progress-cpp Example"
+        )
+
+target_link_libraries(progresscppExample progresscpp)

--- a/example/src/example.cpp
+++ b/example/src/example.cpp
@@ -1,6 +1,6 @@
 #include <iostream>
 #include <unistd.h>
-#include "ProgressBar.hpp"
+#include "progresscpp/ProgressBar.hpp"
 
 /* Example usage of ProgressBar */
 int main() {
@@ -11,7 +11,7 @@ int main() {
      * a width of 70, shows `=` to indicate completion
      * and a blank space for incomplete
      */
-    ProgressBar progressBar(total, 70, '#', '-');
+    progresscpp::ProgressBar progressBar(total, 70, '#', '-');
 
     for (int i = 0; i < total; i++) {
         ++progressBar; // record the tick

--- a/include/progresscpp/ProgressBar.hpp
+++ b/include/progresscpp/ProgressBar.hpp
@@ -1,9 +1,9 @@
-#ifndef PROGRESSBAR_PROGRESSBAR_HPP
-#define PROGRESSBAR_PROGRESSBAR_HPP
+#pragma once
 
 #include <chrono>
 #include <iostream>
 
+namespace progresscpp {
 class ProgressBar {
 private:
     unsigned int ticks = 0;
@@ -16,19 +16,18 @@ private:
 
 public:
     ProgressBar(unsigned int total, unsigned int width, char complete, char incomplete) :
-            total_ticks {total}, bar_width {width}, complete_char {complete}, incomplete_char {incomplete} {}
+            total_ticks{total}, bar_width{width}, complete_char{complete}, incomplete_char{incomplete} {}
 
-    ProgressBar(unsigned int total, unsigned int width) : total_ticks {total}, bar_width {width} {}
+    ProgressBar(unsigned int total, unsigned int width) : total_ticks{total}, bar_width{width} {}
 
     unsigned int operator++() { return ++ticks; }
 
-    void display() const
-    {
+    void display() const {
         float progress = (float) ticks / total_ticks;
         int pos = (int) (bar_width * progress);
 
         std::chrono::steady_clock::time_point now = std::chrono::steady_clock::now();
-        auto time_elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(now-start_time).count();
+        auto time_elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(now - start_time).count();
 
         std::cout << "[";
 
@@ -42,11 +41,9 @@ public:
         std::cout.flush();
     }
 
-    void done() const
-    {
+    void done() const {
         display();
         std::cout << std::endl;
     }
 };
-
-#endif //PROGRESSBAR_PROGRESSBAR_HPP
+}


### PR DESCRIPTION
This allows developers to include your project by simply adding the following to their CMakeLists.txt:

```
CPMAddPackage(
  NAME progresscpp
  GITHUB_REPOSITORY prakhar1989/progress-cpp
  GIT_TAG origin/master
)
target_link_libraries(App progresscpp)
```

And use the project like so, in their c++ files:
```c++
#include "progresscpp/ProgressBar.hpp"
...
progresscpp::ProgressBar progressBar(total, 70, '#', '-');
...
``` 

The functionality is the same.

Based off of this: https://github.com/TheLartians/ModernCppStarter
Uses CPM: https://github.com/TheLartians/CPM.cmake

affects #2