### PR TITLE
compare error and limit to 100%

### DIFF
--- a/include/progresscpp/ProgressBar.hpp
+++ b/include/progresscpp/ProgressBar.hpp
@@ -31,7 +31,7 @@ public:
 
         std::cout << "[";
 
-        for (int i = 0; i < bar_width; ++i) {
+        for (long i = 0; i < long(bar_width); ++i) {
             if (i < pos) std::cout << complete_char;
             else if (i == pos) std::cout << ">";
             else std::cout << incomplete_char;

--- a/include/progresscpp/ProgressBar.hpp
+++ b/include/progresscpp/ProgressBar.hpp
@@ -42,6 +42,7 @@ public:
     }
 
     void done() const {
+        ticks = total_ticks; // can never go beyound 100% for a task
         display();
         std::cout << std::endl;
     }

--- a/include/progresscpp/ProgressBar.hpp
+++ b/include/progresscpp/ProgressBar.hpp
@@ -22,7 +22,7 @@ public:
 
     unsigned int operator++() { return ++ticks; }
 
-    void display() const {
+    void display() {
         float progress = (float) ticks / total_ticks;
         int pos = (int) (bar_width * progress);
 

--- a/include/progresscpp/ProgressBar.hpp
+++ b/include/progresscpp/ProgressBar.hpp
@@ -41,7 +41,7 @@ public:
         std::cout.flush();
     }
 
-    void done() const {
+    void done() {
         ticks = total_ticks; // can never go beyound 100% for a task
         display();
         std::cout << std::endl;


### PR DESCRIPTION
Given that you can't really do more than 100% of a task, it would be intuitive to ensure that the done() function updates the progress bar to show that it is done.

Idea: It might be interesting to later on add a "failure" or "success" method. Where success updates the bar to 100% and failure, stops and displays a potential error message.