### PR TITLE
Fix sign conversion issues

### DIFF
--- a/include/progresscpp/ProgressBar.hpp
+++ b/include/progresscpp/ProgressBar.hpp
@@ -23,15 +23,15 @@ public:
     unsigned int operator++() { return ++ticks; }
 
     void display() const {
-        float progress = (float) ticks / total_ticks;
-        int pos = (int) (bar_width * progress);
+        float progress = static_cast<float>(ticks) / static_cast<float>(total_ticks);
+        unsigned int pos = static_cast<unsigned int>(static_cast<float>(bar_width) * progress);
 
         std::chrono::steady_clock::time_point now = std::chrono::steady_clock::now();
         auto time_elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(now - start_time).count();
 
         std::cout << "[";
 
-        for (int i = 0; i < bar_width; ++i) {
+        for (unsigned int i = 0; i < bar_width; ++i) {
             if (i < pos) std::cout << complete_char;
             else if (i == pos) std::cout << ">";
             else std::cout << incomplete_char;


### PR DESCRIPTION
I was including this on a project of mine where I had `-Wall -Wextra -pedantic` turned on to clean up any extra warnings.  I caught about 4 of them in relation to implicit sign and type conversions.  Adding some `static_cast<>` calls and changing a data type resolved all of the warnings.

For reference, here are the warnings:
```
ProgressBar.hpp: In member function ‘void progresscpp::ProgressBar::display() const’:
ProgressBar.hpp:29:42: warning: conversion to ‘float’ from ‘unsigned int’ may alter its value [-Wconversion]
         float progress = (float) ticks / total_ticks;
                                          ^~~~~~~~~~~
ProgressBar.hpp:30:26: warning: conversion to ‘float’ from ‘unsigned int’ may alter its value [-Wconversion]
         int pos = (int) (bar_width * progress);
                          ^~~~~~~~~
ProgressBar.hpp:37:27: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
         for (int i = 0; i < bar_width; ++i) {
                         ~~^~~~~~~~~~~
ProgressBar.hpp:37:29: warning: conversion to ‘unsigned int’ from ‘int’ may change the sign of the result [-Wsign-conversion]
         for (int i = 0; i < bar_width; ++i) {
```