### PR TITLE
Add license and URL to header of source file

### DIFF
--- a/include/progresscpp/ProgressBar.hpp
+++ b/include/progresscpp/ProgressBar.hpp
@@ -1,3 +1,30 @@
+/****************************************************************************
+(The MIT License)
+
+Copyright (c) 2016 Prakhar Srivastav <prakhar@prakhar.me>
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE
+
+https://github.com/prakhar1989/progress-cpp
+****************************************************************************/
+
 #pragma once
 
 #include <chrono>


### PR DESCRIPTION
Since this seems like something people would just copy into their repos, I think it would be best to add a link to add a license directly in the header (as many other single header libraries do).  As well as a link to the source (for updates).